### PR TITLE
Fix CI environment variable retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ name: CI
 jobs:
   compose-tests:
     runs-on: ubuntu-latest
+    environment: dev
 
     # Segredos viram variáveis de ambiente que o docker-compose consome
     env:


### PR DESCRIPTION
## Summary
- ensure CI uses secrets from the `dev` environment by setting the `environment` key in the workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686145f860ac832c9ab14fa602e993a8