### PR TITLE
Add workflow to publish Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,36 @@
+# .github/workflows/docker-publish.yml
+---
+name: Publish Docker Image
+
+'on':
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker registry
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: app/Dockerfile.app
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/intent-classifier:latest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and publish the Docker image using `app/Dockerfile.app`
- configure the job to run in the `dev` environment

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68615ecbd718832cbcae6d01fbed110a